### PR TITLE
Add a files for Google Ad Manager

### DIFF
--- a/sources/google_ad_manager.json
+++ b/sources/google_ad_manager.json
@@ -1,0 +1,9 @@
+{
+  "id": "GOOGLE_AD_MANAGER",
+  "name": "Google Ad Manager",
+  "categories": ["ADVERTISING"],
+  "organization": "GOOGLE",
+  "iconUrl": "https://www.gstatic.com/admanager/logo_admanager_2x.png",
+  "sourceUrl": "https://admanager.google.com/",
+  "dataVisibility": ["PRIVATE"]
+}


### PR DESCRIPTION
I am requesting to add a source as the source for Google Ad Manager, which was renamed from DoubleClick for Publishers (DFP), does not exist in the repository.